### PR TITLE
Allow using symbols as a condition

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,7 +453,7 @@ the block to only receive one argument.
 
 ### Conditional Attributes
 
-Conditional attributes can be defined by passing a Proc to the `if` key on the `attribute` method. Return `true` if the attribute should be serialized, and `false` if not. The record and any params passed to the serializer are available inside the Proc as the first and second parameters, respectively.
+Conditional attributes can be defined by passing a Proc or a symbolized name of a method defined in the serializer to the `if` key on the `attribute` method. Return `true` if the attribute should be serialized, and `false` if not. The record and any params passed to the serializer are available inside the Proc as the first and second parameters, respectively.
 
 ```ruby
 class MovieSerializer
@@ -469,6 +469,19 @@ class MovieSerializer
     # The director will be serialized only if the :admin key of params is true
     params && params[:admin] == true
   }
+
+  attribute :country, if: :show_country
+  attribute :rating, if: :show_rating
+
+  def show_country(_object, params)
+    # The country will be serialized only if the :admin key of params is true
+    params.try(:admin) == true
+  end
+
+  def show_rating(object)
+    # The rating will be shown only if it's higher than 2
+    object.rating > 2
+  end
 end
 
 # ...
@@ -476,6 +489,7 @@ current_user = User.find(cookies[:current_user_id])
 serializer = MovieSerializer.new(movie, { params: { admin: current_user.admin? }})
 serializer.serializable_hash
 ```
+The same stands for links and `link` method.
 
 ### Conditional Relationships
 

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -211,7 +211,8 @@ module FastJsonapi
           attributes_to_serialize[key] = Attribute.new(
             key: key,
             method: block || method_name,
-            options: options
+            options: options,
+            serializer: self
           )
         end
       end
@@ -330,7 +331,8 @@ module FastJsonapi
         data_links[key] = Link.new(
           key: key,
           method: block || link_method_name,
-          options: options
+          options: options,
+          serializer: self
         )
       end
 

--- a/lib/fast_jsonapi/relationship.rb
+++ b/lib/fast_jsonapi/relationship.rb
@@ -150,7 +150,7 @@ module FastJsonapi
                                    record.public_send(links)
                                  else
                                    links.each_with_object({}) do |(key, method), hash|
-                                     Link.new(key: key, method: method).serialize(record, params, hash)
+                                     Link.new(key: key, method: method, serializer: serializer).serialize(record, params, hash)
                                    end
                                  end
     end

--- a/spec/fixtures/actor.rb
+++ b/spec/fixtures/actor.rb
@@ -1,12 +1,14 @@
 require 'active_support/cache'
 
 class Actor < User
-  attr_accessor :movies, :movie_ids
+  attr_accessor :movies, :movie_ids, :age, :birthplace, :show_birthplace
 
   def self.fake(id = nil)
     faked = super(id)
     faked.movies = []
     faked.movie_ids = []
+    faked.age = rand(99)
+    faked.birthplace = FFaker::Address.city
     faked
   end
 
@@ -21,6 +23,8 @@ class ActorSerializer < UserSerializer
   set_type :actor
 
   attribute :email, if: ->(_object, params) { params[:conditionals_off].nil? }
+  attribute :age, if: :symbol_conditionals_off
+  attribute :birthplace, if: :show_birthplace
 
   has_many(
     :played_movies,
@@ -29,6 +33,14 @@ class ActorSerializer < UserSerializer
     if: ->(_object, params) { params[:conditionals_off].nil? }
   ) do |object|
     object.movies
+  end
+
+  def symbol_conditionals_off(_object, params)
+    params[:symbol_conditionals_off].nil?
+  end
+
+  def show_birthplace(object)
+    object.show_birthplace
   end
 end
 

--- a/spec/integration/attributes_fields_spec.rb
+++ b/spec/integration/attributes_fields_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe FastJsonapi::ObjectSerializer do
       expect(serialized['data']).to have_type('actor')
 
       expect(serialized['data'])
-        .to have_jsonapi_attributes('first_name', 'last_name', 'email').exactly
+        .to have_jsonapi_attributes('first_name', 'last_name', 'email', 'age').exactly
       expect(serialized['data']).to have_attribute('first_name')
         .with_value(actor.first_name)
       expect(serialized['data']).to have_attribute('last_name')
@@ -33,10 +33,28 @@ RSpec.describe FastJsonapi::ObjectSerializer do
     end
 
     context 'with `if` conditions' do
-      let(:params) { { params: { conditionals_off: 'yes' } } }
+      context 'when condition is a proc' do
+        let(:params) { { params: { conditionals_off: 'yes' } } }
 
-      it do
-        expect(serialized['data']).not_to have_attribute('email')
+        it do
+          expect(serialized['data']).not_to have_attribute('email')
+        end
+
+        context 'when condition is a symbol and method accepts params' do
+          let(:params) { { params: { symbol_conditionals_off: 'yes' } } }
+
+          it do
+            expect(serialized['data']).not_to have_attribute('age')
+          end
+        end
+
+        context 'when condition is a symbol and method accepts only record' do
+          before { actor.show_birthplace = true }
+
+          it do
+            expect(serialized['data']).to have_attribute('birthplace')
+          end
+        end
       end
     end
 


### PR DESCRIPTION
By now, if I want to add a conditional attribute or link, I should provide a proc as a value for `if` key. It may look awkward, especially if there is a block passed along with the condition.

I suggest allowing to pass a symbol as a value for `if` key, which is the name of a method defined below in the serializer. It seems to be common in ruby/rails, e.g. in conditional callbacks in Rails.


## What is the current behavior?


```
attribute :name, if: ->(object) { object.show_name }
link :url, if: ->(_object, params) { params.show_url }
```

## What is the new behavior?

We can provide a symbolized serializer method name as a value for `if` key
```
class MovieSerializer
  include JSONAPI::Serializer

  attribute :country, if: :show_country
  attribute :rating, if: :show_rating

  def show_country(_object, params)
    # The country will be serialized only if the :admin key of params is true
    params.try(:admin) == true
  end

  def show_rating(object)
    # The rating will be shown only if it's higher than 2
    object.rating > 2
  end
end

```

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [ ] All automated checks pass (CI/CD)
