### PR TITLE
Performance optimize include behavior

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -337,21 +337,11 @@ module FastJsonapi
       def validate_includes!(includes)
         return if includes.blank?
 
-        includes.each do |include_item|
-          klass = self
-          parse_include_item(include_item).each do |parsed_include|
-            relationships_to_serialize = klass.relationships_to_serialize || {}
-            relationship_to_include = relationships_to_serialize[parsed_include]
-            raise ArgumentError, "#{parsed_include} is not specified as a relationship on #{klass.name}" unless relationship_to_include
+        parse_includes_list(includes).keys.each do |include_item|
+          relationship_to_include = relationships_to_serialize[include_item]
+          raise ArgumentError, "#{include_item} is not specified as a relationship on #{name}" unless relationship_to_include
 
-            if relationship_to_include.static_serializer
-              klass = relationship_to_include.static_serializer
-            else
-              # the serializer may change based on the object (e.g. polymorphic relationships),
-              # so inner relationships cannot be validated
-              break
-            end
-          end
+          relationship_to_include.static_serializer # called for a side-effect to check for a known serializer class.
         end
       end
     end

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -80,7 +80,7 @@ module FastJsonapi
 
       return if options.blank?
 
-      @known_included_objects = {}
+      @known_included_objects = Set.new
       @meta = options[:meta]
       @links = options[:links]
       @is_collection = options[:is_collection]

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -123,10 +123,8 @@ module FastJsonapi
 
             relationship_type = relationship_item.relationship_type
 
-            included_objects = relationship_item.fetch_associated_object(record, params)
-            next if included_objects.blank?
-
-            included_objects = [included_objects] unless relationship_type == :has_many
+            included_objects = Array(relationship_item.fetch_associated_object(record, params))
+            next if included_objects.empty?
 
             static_serializer = relationship_item.static_serializer
             static_record_type = relationship_item.static_record_type

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -114,8 +114,6 @@ module FastJsonapi
 
           next unless relationship_item && relationship_item.include_relationship?(record, params)
 
-          relationship_type = relationship_item.relationship_type
-
           included_objects = Array(relationship_item.fetch_associated_object(record, params))
           next if included_objects.empty?
 

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -110,10 +110,9 @@ module FastJsonapi
         includes_list = parse_includes_list(includes_list)
 
         includes_list.each_with_object([]) do |include_item, included_records|
-          next unless relationships_to_serialize[include_item.first]
-
           relationship_item = relationships_to_serialize[include_item.first]
-          next unless relationship_item.include_relationship?(record, params)
+
+          next unless relationship_item && relationship_item.include_relationship?(record, params)
 
           relationship_type = relationship_item.relationship_type
 

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -112,7 +112,7 @@ module FastJsonapi
         includes_list.each_with_object([]) do |include_item, included_records|
           relationship_item = relationships_to_serialize[include_item.first]
 
-          next unless relationship_item && relationship_item.include_relationship?(record, params)
+          next unless relationship_item&.include_relationship?(record, params)
 
           included_objects = Array(relationship_item.fetch_associated_object(record, params))
           next if included_objects.empty?

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -111,7 +111,7 @@ module FastJsonapi
         return unless includes_list.present?
         return [] unless relationships_to_serialize
 
-        includes_list.sort.each_with_object([]) do |include_item, included_records|
+        includes_list.each_with_object([]) do |include_item, included_records|
           items = parse_include_item(include_item)
           remaining_items = remaining_items(items)
 

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -109,13 +109,14 @@ module FastJsonapi
       # includes handler
       def get_included_records(record, includes_list, known_included_objects, fieldsets, params = {})
         return unless includes_list.present?
+        return [] unless relationships_to_serialize
 
         includes_list.sort.each_with_object([]) do |include_item, included_records|
           items = parse_include_item(include_item)
           remaining_items = remaining_items(items)
 
           items.each do |item|
-            next unless relationships_to_serialize && relationships_to_serialize[item]
+            next unless relationships_to_serialize[item]
 
             relationship_item = relationships_to_serialize[item]
             next unless relationship_item.include_relationship?(record, params)

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -133,9 +133,9 @@ module FastJsonapi
             end
 
             code = "#{record_type}_#{serializer.id_from_record(inc_obj, params)}"
-            next if known_included_objects.key?(code)
+            next if known_included_objects.include?(code)
 
-            known_included_objects[code] = inc_obj
+            known_included_objects << code
 
             included_records << serializer.record_hash(inc_obj, fieldsets[record_type], includes_list, params)
           end


### PR DESCRIPTION
## What is the current behavior?

Currently (v2.0.0), the logic for loading and serializing included records is highly-inefficient. Further, it appears to have an errant (albeit ignored) behavior. This inefficiency is exacerbated with a large and/or deeply nested set of included objects, which causes exponential growth in object allocation, iteration, and object checking.

Regarding the errant behavior, the current implementation attempts to query a parent object for all nested, included associations. Hard to describe, but using this library's spec fixtures as an example: If I serialize a Movie and ask to `include: [:actors, :'actors.played_movies']`, then the Movie instance is checked for both "actors" and "played_movies". Played movies should not be checked on the movie, only on the associated actors. The current library hides this error with a `next` check, but it still loops and runs. This error is where the exponential iteration growth comes from with deeply nested includes.

Anyway, with the current v2.0.0 release, using a large, deeply nested object set, I was finding results similar to the following when using already-loaded-in-memory object sets (these numbers are strictly for performing the `serializable_hash` call and Oj JSON dump, skipping the database load and whatever else occurred before it):

Serialization (wall) Time: 6090.6ms
Allocations: 14974152

## What is the new behavior?

There is no difference in external behavior. There are, however, significant improvements in object allocation and execution times. After these changes, the same data set and request see numbers like:

Serialization (wall) Time: 769.6ms
Allocations: 1171848

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)
