### PR TITLE
Prevent incorrect fieldset caching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Remove `ObjectSerializer#serialized_json` (#91)
 
+### Fixed
+- Ensure caching correctly incorporates fieldset information into the cache key to prevent incorrect fieldset caching (#90)
+
 ## [1.7.2] - 2020-05-18
 ### Fixed
 - Relationship#record_type_for does not assign static record type for polymorphic relationships (#83)

--- a/README.md
+++ b/README.md
@@ -409,6 +409,25 @@ So for the example above it will call the cache instance like this:
 Rails.cache.fetch(record, namespace: 'jsonapi-serializer', expires_in: 1.hour) { ... }
 ```
 
+#### Caching and Sparse Fieldsets
+
+If caching is enabled and fields are provided to the serializer, the fieldset will be appended to the cache key's namespace.
+
+For example, given the following serializer definition and instance:
+```ruby
+class ActorSerializer
+  include JSONAPI::Serializer
+
+  attributes :first_name, :last_name
+
+  cache_options store: Rails.cache, namespace: 'jsonapi-serializer', expires_in: 1.hour
+end
+
+serializer = ActorSerializer.new(actor, { fields: { actor: [:first_name] } })
+```
+
+The following cache namespace will be generated: `'jsonapi-serializer-fieldset:first_name'`.
+
 ### Params
 
 In some cases, attribute values might require more information than what is
@@ -469,7 +488,7 @@ class MovieSerializer
     # The director will be serialized only if the :admin key of params is true
     params && params[:admin] == true
   }
-  
+
   # Custom attribute `name_year` will only be serialized if both `name` and `year` fields are present
   attribute :name_year, if: Proc.new { |record|
     record.name.present? && record.year.present?

--- a/spec/integration/caching_spec.rb
+++ b/spec/integration/caching_spec.rb
@@ -26,4 +26,45 @@ RSpec.describe FastJsonapi::ObjectSerializer do
       ).to be(false)
     end
   end
+
+  describe 'with caching and different fieldsets' do
+    context 'when fieldset is provided' do
+      it 'includes the fieldset in the namespace' do
+        expect(cache_store.delete(actor, namespace: 'test')).to be(false)
+
+        Cached::ActorSerializer.new(
+          [actor], fields: { actor: %i[first_name] }
+        ).serializable_hash
+
+        # Expect cached keys to match the passed fieldset
+        expect(cache_store.read(actor, namespace: 'test-fieldset:first_name')[:attributes].keys).to eq(%i[first_name])
+
+        Cached::ActorSerializer.new(
+          [actor]
+        ).serializable_hash
+
+        # Expect cached keys to match all valid actor fields (no fieldset)
+        expect(cache_store.read(actor, namespace: 'test')[:attributes].keys).to eq(%i[first_name last_name email])
+        expect(cache_store.delete(actor, namespace: 'test')).to be(true)
+        expect(cache_store.delete(actor, namespace: 'test-fieldset:first_name')).to be(true)
+      end
+    end
+
+    context 'when long fieldset is provided' do
+      let(:actor_keys) { %i[first_name last_name more_fields yet_more_fields so_very_many_fields] }
+      let(:digest_key) { Digest::SHA1.hexdigest(actor_keys.join('_')) }
+
+      it 'includes the hashed fieldset in the namespace' do
+        Cached::ActorSerializer.new(
+          [actor], fields: { actor: actor_keys }
+        ).serializable_hash
+
+        expect(cache_store.read(actor, namespace: "test-fieldset:#{digest_key}")[:attributes].keys).to eq(
+          %i[first_name last_name]
+        )
+
+        expect(cache_store.delete(actor, namespace: "test-fieldset:#{digest_key}")).to be(true)
+      end
+    end
+  end
 end


### PR DESCRIPTION
This change alters the cache namespace prior to retrieving cached record
data to ensure that different fieldsets are given different cache keys.

Previously, all cache keys for the same record would be specified
identically, leading to a situation where the fieldset would be ignored
if record caching is enabled.

Fixes #90.

## What is the current behavior?
See #90 

## What is the new behavior?

The cache namespace is now altered prior to gathering cached entries with specific fieldsets. If a fieldset is specified, `"-fieldset:#{fieldset.join('_')"` will be appended to the cache namespace.

For example, if the fields `a`, `b`, and `c` were requested and the main namespace is `ns`, the generated namespace would be `ns-fieldset:a_b_c`.

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] All automated checks pass (CI/CD)
