### PR TITLE
fix: Rename FastJsonapi::ObjectSerializer to JSONAPI::Serializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -677,8 +677,8 @@ require 'fast_jsonapi/instrumentation'
 ```
 
 The two instrumented notifications are supplied by these two constants:
-* `FastJsonapi::ObjectSerializer::SERIALIZABLE_HASH_NOTIFICATION`
-* `FastJsonapi::ObjectSerializer::SERIALIZED_JSON_NOTIFICATION`
+* `JSONAPI::Serializer::SERIALIZABLE_HASH_NOTIFICATION`
+* `JSONAPI::Serializer::SERIALIZED_JSON_NOTIFICATION`
 
 It is also possible to instrument one method without the other by using one of the following require statements:
 

--- a/docs/json_serialization.md
+++ b/docs/json_serialization.md
@@ -13,7 +13,7 @@ require 'oj'
 require 'fast_jsonapi'
 
 class BaseSerializer
-  include FastJsonapi::ObjectSerializer
+  include JSONAPI::Serializer
 
   def to_json
     Oj.dump(serializable_hash)

--- a/lib/fast_jsonapi/instrumentation/skylight/normalizers/serializable_hash.rb
+++ b/lib/fast_jsonapi/instrumentation/skylight/normalizers/serializable_hash.rb
@@ -6,9 +6,9 @@ module FastJsonapi
     module Skylight
       module Normalizers
         class SerializableHash < SKYLIGHT_NORMALIZER_BASE_CLASS
-          register FastJsonapi::ObjectSerializer::SERIALIZABLE_HASH_NOTIFICATION
+          register JSONAPI::Serializer::SERIALIZABLE_HASH_NOTIFICATION
 
-          CAT = "view.#{FastJsonapi::ObjectSerializer::SERIALIZABLE_HASH_NOTIFICATION}".freeze
+          CAT = "view.#{JSONAPI::Serializer::SERIALIZABLE_HASH_NOTIFICATION}".freeze
 
           def normalize(_trace, _name, payload)
             [CAT, payload[:name], nil]

--- a/lib/fast_jsonapi/instrumentation/skylight/normalizers/serialized_json.rb
+++ b/lib/fast_jsonapi/instrumentation/skylight/normalizers/serialized_json.rb
@@ -6,9 +6,9 @@ module FastJsonapi
     module Skylight
       module Normalizers
         class SerializedJson < SKYLIGHT_NORMALIZER_BASE_CLASS
-          register FastJsonapi::ObjectSerializer::SERIALIZED_JSON_NOTIFICATION
+          register JSONAPI::Serializer::SERIALIZED_JSON_NOTIFICATION
 
-          CAT = "view.#{FastJsonapi::ObjectSerializer::SERIALIZED_JSON_NOTIFICATION}".freeze
+          CAT = "view.#{JSONAPI::Serializer::SERIALIZED_JSON_NOTIFICATION}".freeze
 
           def normalize(_trace, _name, payload)
             [CAT, payload[:name], nil]

--- a/lib/generators/serializer/templates/serializer.rb.tt
+++ b/lib/generators/serializer/templates/serializer.rb.tt
@@ -1,6 +1,6 @@
 <% module_namespacing do -%>
 class <%= class_name %>Serializer
-  include FastJsonapi::ObjectSerializer
+  include JSONAPI::Serializer
   attributes <%= attributes_names.join(", ") %>
 end
 <% end -%>

--- a/spec/integration/attributes_fields_spec.rb
+++ b/spec/integration/attributes_fields_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe FastJsonapi::ObjectSerializer do
+RSpec.describe JSONAPI::Serializer do
   let(:actor) do
     act = Actor.fake
     act.movies = [Movie.fake]

--- a/spec/integration/caching_spec.rb
+++ b/spec/integration/caching_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe FastJsonapi::ObjectSerializer do
+RSpec.describe JSONAPI::Serializer do
   let(:actor) do
     faked = Actor.fake
     movie = Movie.fake

--- a/spec/integration/errors_spec.rb
+++ b/spec/integration/errors_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe FastJsonapi::ObjectSerializer do
+RSpec.describe JSONAPI::Serializer do
   let(:actor) { Actor.fake }
   let(:params) { {} }
 

--- a/spec/integration/key_transform_spec.rb
+++ b/spec/integration/key_transform_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe FastJsonapi::ObjectSerializer do
+RSpec.describe JSONAPI::Serializer do
   let(:actor) { Actor.fake }
   let(:params) { {} }
   let(:serialized) do

--- a/spec/integration/links_spec.rb
+++ b/spec/integration/links_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe FastJsonapi::ObjectSerializer do
+RSpec.describe JSONAPI::Serializer do
   let(:movie) do
     faked = Movie.fake
     faked.actors = [Actor.fake]

--- a/spec/integration/meta_spec.rb
+++ b/spec/integration/meta_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe FastJsonapi::ObjectSerializer do
+RSpec.describe JSONAPI::Serializer do
   let(:user) { User.fake }
   let(:params) { {} }
   let(:serialized) do

--- a/spec/integration/relationships_spec.rb
+++ b/spec/integration/relationships_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe FastJsonapi::ObjectSerializer do
+RSpec.describe JSONAPI::Serializer do
   let(:movie) do
     mov = Movie.fake
     mov.actors = rand(2..5).times.map { Actor.fake }


### PR DESCRIPTION
As the project has been renamed, its better to reflect it in the source code as well.
`JSONAPI::Serializer` is evaluated from `FastJsonapi::ObjectSerializer` so this change  probably will go unnoticed in gem usage.

## What is the current behavior?
Being a fast_jsonapi fork, FastJsonapi::ObjectSerializer is used.

## What is the new behavior?
As #86 has been resolved, the `fast_jsonapi` namespace should be replaced with the `jsonapi-serializer`.
As a first step the PR replaces FastJsonapi::ObjectSerializer with JSONAPI::Serializer.

TODO
- [ ] Add jsonapi_serializer.rb

## Checklist

Please make sure the following requirements are complete:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)
