### PR TITLE
Do not add empty relationships key

### DIFF
--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -70,12 +70,11 @@ module FastJsonapi
           record_hash = cache_store_instance.fetch(record, **cache_options_with_fieldsets(cache_store_options, fieldset)) do
             temp_hash = id_hash(id_from_record(record, params), record_type, true)
             temp_hash[:attributes] = attributes_hash(record, fieldset, params) if attributes_to_serialize.present?
-            temp_hash[:relationships] = {}
             temp_hash[:relationships] = relationships_hash(record, cachable_relationships_to_serialize, fieldset, includes_list, params) if cachable_relationships_to_serialize.present?
             temp_hash[:links] = links_hash(record, params) if data_links.present?
             temp_hash
           end
-          record_hash[:relationships] = record_hash[:relationships].merge(relationships_hash(record, uncachable_relationships_to_serialize, fieldset, includes_list, params)) if uncachable_relationships_to_serialize.present?
+          record_hash[:relationships] = (record_hash[:relationships] || {}).merge(relationships_hash(record, uncachable_relationships_to_serialize, fieldset, includes_list, params)) if uncachable_relationships_to_serialize.present?
         else
           record_hash = id_hash(id_from_record(record, params), record_type, true)
           record_hash[:attributes] = attributes_hash(record, fieldset, params) if attributes_to_serialize.present?

--- a/spec/fixtures/_user.rb
+++ b/spec/fixtures/_user.rb
@@ -1,3 +1,5 @@
+require 'active_support/cache'
+
 class User
   attr_accessor :uid, :first_name, :last_name, :email
 
@@ -24,5 +26,14 @@ class UserSerializer
     {
       email_length: obj.email.size
     }
+  end
+end
+
+module Cached
+  class UserSerializer < ::UserSerializer
+    cache_options(
+      store: ActiveSupport::Cache::MemoryStore.new,
+      namespace: 'test'
+    )
   end
 end

--- a/spec/integration/caching_spec.rb
+++ b/spec/integration/caching_spec.rb
@@ -25,6 +25,16 @@ RSpec.describe FastJsonapi::ObjectSerializer do
         cache_store.delete(actor.movies[0].owner, namespace: 'test')
       ).to be(false)
     end
+
+    context 'without relationships' do
+      let(:user) { User.fake }
+
+      let(:serialized) { Cached::UserSerializer.new(user).serializable_hash.as_json }
+
+      it do
+        expect(serialized['data']).not_to have_key('relationships')
+      end
+    end
   end
 
   describe 'with caching and different fieldsets' do


### PR DESCRIPTION
## What is the current behavior?

When using caching, the serialized hash differs from the one without caching because the empty `relationships` key is added. 

## What is the new behavior?

Changing the serialization logic so that the `relationships` key is added only if relationships are present.
