### PR TITLE
Detect enumerables strictly. Closes #112

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -36,7 +36,9 @@ module FastJsonapi
     end
 
     def serializable_hash
-      return hash_for_collection if is_collection?(@resource, @is_collection)
+      if self.class.is_collection?(@resource, @is_collection)
+        return hash_for_collection
+      end
 
       hash_for_one_record
     end
@@ -105,13 +107,16 @@ module FastJsonapi
       end
     end
 
-    def is_collection?(resource, force_is_collection = nil)
-      return force_is_collection unless force_is_collection.nil?
-
-      resource.respond_to?(:each) && !resource.respond_to?(:each_pair)
-    end
-
     class_methods do
+      # Detects a collection/enumerable
+      #
+      # @return [TrueClass] on a successful detection
+      def is_collection?(resource, force_is_collection = nil)
+        return force_is_collection unless force_is_collection.nil?
+
+        resource.is_a?(Enumerable) && !resource.respond_to?(:each_pair)
+      end
+
       def inherited(subclass)
         super(subclass)
         subclass.attributes_to_serialize = attributes_to_serialize.dup if attributes_to_serialize.present?


### PR DESCRIPTION
## What is the current behavior?

We assume a collection is to be serialized if the object has an `each` method. This causes inconsistencies, for ex #112 

## What is the new behavior?

We strictly try to detect if the object is an `Enumerable` as it's the commonly recommended way to detect collections.

Finally, this method is a public method now, and can be used by third-party libraries.

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)
