### PR TITLE
Raise FastJsonapi scoped error in case of unsupported include

### DIFF
--- a/lib/fast_jsonapi.rb
+++ b/lib/fast_jsonapi.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'jsonapi/serializer/errors'
+
 module FastJsonapi
   require 'fast_jsonapi/object_serializer'
   if defined?(::Rails)

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -342,7 +342,7 @@ module FastJsonapi
 
         parse_includes_list(includes).keys.each do |include_item|
           relationship_to_include = relationships_to_serialize[include_item]
-          raise ArgumentError, "#{include_item} is not specified as a relationship on #{name}" unless relationship_to_include
+          raise(JSONAPI::Serializer::UnsupportedIncludeError.new(include_item, name)) unless relationship_to_include
 
           relationship_to_include.static_serializer # called for a side-effect to check for a known serializer class.
         end

--- a/lib/jsonapi/serializer/errors.rb
+++ b/lib/jsonapi/serializer/errors.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module JSONAPI
+  module Serializer
+    class Error < StandardError; end
+    class UnsupportedIncludeError < Error
+      attr_reader :include_item, :klass
+
+      def initialize(include_item, klass)
+        @include_item = include_item
+        @klass = klass
+      end
+
+      def message
+        "#{include_item} is not specified as a relationship on #{klass}"
+      end
+    end
+  end
+end

--- a/spec/integration/errors_spec.rb
+++ b/spec/integration/errors_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe JSONAPI::Serializer do
     it do
       expect { ActorSerializer.new(actor, include: ['bad_include']) }
         .to raise_error(
-          ArgumentError, /bad_include is not specified as a relationship/
+          JSONAPI::Serializer::UnsupportedIncludeError, /bad_include is not specified as a relationship/
         )
     end
   end


### PR DESCRIPTION
## What is the current behavior?

Currently the gem throws `ArgumentError` in case given include is not declared in serializer. `ArgumentError` is too broad and does not allow to safely rescue this error.

Particular use case:

I want to intercept this error and show it to end user as a validation error message. With the custom error class it is much easier to do. 

## What is the new behavior?

Serializers throw `JSONAPI::UnsupportedIncludeError` that is more specific and allows to retrieve invalid include value for validation response.
