### PR TITLE
Support procs as the value of lazy_load_data parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 - ...
+## [2.2.0] - 2020-09-17
+
+### Added
+- Support procs as the value of lazy_load_data parameter in has_many relationships
 
 ## [2.1.0] - 2020-08-30
 

--- a/README.md
+++ b/README.md
@@ -301,6 +301,17 @@ This will create a `self` reference for the relationship, and a `related` link f
   }
 ```
 
+The value of `lazy_load_data` can be a proc if you need to use it depending on external parameters
+
+```ruby
+  has_many :actors, lazy_load_data: proc { |_, params| params[:lazy_load_actors_data] }, links: {
+    self: :url,
+    related: -> (object) {
+      "https://movies.com/#{object.id}/actors"
+    }
+  }
+```
+
 ### Meta Per Resource
 
 For every resource in the collection, you can include a meta object containing non-standard meta-information about a resource that can not be represented as an attribute or relationship.

--- a/lib/fast_jsonapi/relationship.rb
+++ b/lib/fast_jsonapi/relationship.rb
@@ -45,7 +45,7 @@ module FastJsonapi
         empty_case = relationship_type == :has_many ? [] : nil
 
         output_hash[key] = {}
-        output_hash[key][:data] = ids_hash_from_record_and_relationship(record, serialization_params) || empty_case unless lazy_load_data && !included
+        output_hash[key][:data] = ids_hash_from_record_and_relationship(record, serialization_params) || empty_case unless lazy_load_data?(record, serialization_params) && !included
 
         add_meta_hash(record, serialization_params, output_hash) if meta.present?
         add_links_hash(record, serialization_params, output_hash) if links.present?
@@ -99,6 +99,10 @@ module FastJsonapi
     end
 
     private
+
+    def lazy_load_data?(record, serialization_params)
+      lazy_load_data.is_a?(Proc) ? FastJsonapi.call_proc(lazy_load_data, record, serialization_params) : lazy_load_data
+    end
 
     def ids_hash_from_record_and_relationship(record, params = {})
       initialize_static_serializer unless @initialized_static_serializer

--- a/lib/jsonapi/serializer/version.rb
+++ b/lib/jsonapi/serializer/version.rb
@@ -1,5 +1,5 @@
 module JSONAPI
   module Serializer
-    VERSION = '2.1.0'.freeze
+    VERSION = '2.2.0'.freeze
   end
 end

--- a/spec/fixtures/comment.rb
+++ b/spec/fixtures/comment.rb
@@ -1,0 +1,18 @@
+class Comment
+  attr_accessor :uid, :body
+
+  def self.fake(id = nil)
+    faked = new
+    faked.uid = id || SecureRandom.uuid
+    faked.body = FFaker::Lorem.paragraph
+
+    faked
+  end
+end
+
+class CommentSerializer
+  include JSONAPI::Serializer
+
+  set_id :uid
+  attributes :body
+end

--- a/spec/fixtures/movie.rb
+++ b/spec/fixtures/movie.rb
@@ -8,7 +8,9 @@ class Movie
     :actor_ids,
     :polymorphics,
     :owner,
-    :owner_id
+    :owner_id,
+    :comments,
+    :comment_ids
   )
 
   def self.fake(id = nil)
@@ -19,6 +21,8 @@ class Movie
     faked.actors = []
     faked.actor_ids = []
     faked.polymorphics = []
+    faked.comments = []
+    faked.comment_ids = []
     faked
   end
 
@@ -40,6 +44,11 @@ class Movie
       actor.movies << self
       actor.uid
     end
+  end
+
+  def comments=(comments)
+    @comments = comments
+    @comment_ids = comments.map(&:uid)
   end
 end
 
@@ -103,6 +112,15 @@ class MovieSerializer
   ) do |obj|
     obj.polymorphics
   end
+
+  has_many(
+    :comments,
+    lazy_load_data: proc { |_, params| params[:lazy_load_comments_data] },
+    links: {
+      comments_self: :url,
+      related: ->(obj) { obj.url(obj) }
+    }
+  )
 end
 
 module Cached


### PR DESCRIPTION
Support procs as the value of lazy_load_data parameter in has_many relationships https://github.com/jsonapi-serializer/jsonapi-serializer/issues/123

## What is the current behaviour?

The value of `lazy_load_data` can be only a boolean

## What is the new behavior?

The value of `lazy_load_data` can be a proc if you need to use it depending on external parameters

```ruby
  has_many :actors, lazy_load_data: proc { |_, params| params[:lazy_load_actors_data] }, links: {
    self: :url,
    related: -> (object) {
      "https://movies.com/#{object.id}/actors"
    }
  }
```

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)
