### PR TITLE
Handle a heterogeneous collection via serializers option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-- ...
+
+### Added
+- Add support for collections of mixed classes (#121)
 
 ## [2.1.0] - 2020-08-30
 

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -49,8 +49,9 @@ module FastJsonapi
 
       return serializable_hash unless @resource
 
-      serializable_hash[:data] = self.class.record_hash(@resource, @fieldsets[self.class.record_type.to_sym], @includes, @params)
-      serializable_hash[:included] = self.class.get_included_records(@resource, @includes, @known_included_objects, @fieldsets, @params) if @includes.present?
+      serializer_class = serializer_for(@resource)
+      serializable_hash[:data] = serializer_class.record_hash(@resource, @fieldsets[serializer_class.record_type.to_sym], @includes, @params)
+      serializable_hash[:included] = serializer_class.get_included_records(@resource, @includes, @known_included_objects, @fieldsets, @params) if @includes.present?
       serializable_hash
     end
 
@@ -59,10 +60,11 @@ module FastJsonapi
 
       data = []
       included = []
-      fieldset = @fieldsets[self.class.record_type.to_sym]
       @resource.each do |record|
-        data << self.class.record_hash(record, fieldset, @includes, @params)
-        included.concat self.class.get_included_records(record, @includes, @known_included_objects, @fieldsets, @params) if @includes.present?
+        serializer_class = serializer_for(record)
+        fieldset = @fieldsets[serializer_class.record_type.to_sym]
+        data << serializer_class.record_hash(record, fieldset, @includes, @params)
+        included.concat serializer_class.get_included_records(record, @includes, @known_included_objects, @fieldsets, @params) if @includes.present?
       end
 
       serializable_hash[:data] = data
@@ -91,6 +93,12 @@ module FastJsonapi
         @includes = options[:include].reject(&:blank?).map(&:to_sym)
         self.class.validate_includes!(@includes)
       end
+
+      @serializers = options.fetch(:serializers, {}).transform_keys do |key|
+        next key if key.is_a?(Class)
+
+        key.to_s.constantize
+      end
     end
 
     def deep_symbolize(collection)
@@ -103,6 +111,12 @@ module FastJsonapi
       else
         collection.to_sym
       end
+    end
+
+    def serializer_for(record)
+      return self.class if @serializers.blank?
+
+      @serializers[record.class] || raise(ArgumentError, "no serializer defined for #{record.class}")
     end
 
     class_methods do

--- a/spec/fixtures/_vehicle.rb
+++ b/spec/fixtures/_vehicle.rb
@@ -1,0 +1,12 @@
+class Vehicle
+  attr_accessor :id, :model, :year
+
+  def type
+    self.class.name.downcase
+  end
+end
+
+class VehicleSerializer
+  include JSONAPI::Serializer
+  attributes :model, :year
+end

--- a/spec/fixtures/bus.rb
+++ b/spec/fixtures/bus.rb
@@ -1,0 +1,16 @@
+class Bus < Vehicle
+  attr_accessor :passenger_count
+
+  def self.fake(id = nil)
+    faked = new
+    faked.id = id || SecureRandom.uuid
+    faked.model = 'Nova Bus LFS'
+    faked.year = 2014
+    faked.passenger_count = 60
+    faked
+  end
+end
+
+class BusSerializer < VehicleSerializer
+  attribute :passenger_count
+end

--- a/spec/fixtures/car.rb
+++ b/spec/fixtures/car.rb
@@ -1,0 +1,16 @@
+class Car < Vehicle
+  attr_accessor :purchased_at
+
+  def self.fake(id = nil)
+    faked = new
+    faked.id = id || SecureRandom.uuid
+    faked.model = 'Toyota Corolla'
+    faked.year = 1987
+    faked.purchased_at = Time.new(2018, 1, 1)
+    faked
+  end
+end
+
+class CarSerializer < VehicleSerializer
+  attribute :purchased_at
+end

--- a/spec/fixtures/truck.rb
+++ b/spec/fixtures/truck.rb
@@ -1,0 +1,11 @@
+class Truck < Vehicle
+  attr_accessor :load
+
+  def self.fake(id = nil)
+    faked = new
+    faked.id = id || SecureRandom.uuid
+    faked.model = 'Ford F150'
+    faked.year = 2000
+    faked
+  end
+end

--- a/spec/integration/mixed_collection_spec.rb
+++ b/spec/integration/mixed_collection_spec.rb
@@ -1,0 +1,59 @@
+require 'spec_helper'
+
+RSpec.describe JSONAPI::Serializer do
+  let(:car) { Car.fake }
+  let(:bus) { Bus.fake }
+  let(:truck) { Truck.fake }
+
+  context 'when serializing a mixed collection' do
+    it 'uses the correct serializer for each object' do
+      vehicles = VehicleSerializer.new([car, bus], serializers: { Car: CarSerializer, Bus: BusSerializer }).to_hash
+      car_hash, bus_hash = vehicles[:data]
+
+      expect(car_hash[:type]).to eq(:car)
+      expect(car_hash[:attributes]).to eq(model: car.model, year: car.year, purchased_at: car.purchased_at)
+
+      expect(bus_hash[:type]).to eq(:bus)
+      expect(bus_hash[:attributes]).to eq(model: bus.model, year: bus.year, passenger_count: bus.passenger_count)
+    end
+
+    context 'when there is no serializer given for the class' do
+      it 'raises ArgumentError' do
+        expect { VehicleSerializer.new([truck], serializers: { Car: CarSerializer, Bus: BusSerializer }).to_hash }
+          .to raise_error(ArgumentError, 'no serializer defined for Truck')
+      end
+    end
+
+    context 'when given an empty set of serializers' do
+      it 'uses the serializer being called' do
+        data = VehicleSerializer.new([truck], serializers: {}).to_hash[:data][0]
+        expect(data[:type]).to eq(:vehicle)
+        expect(data[:attributes]).to eq(model: truck.model, year: truck.year)
+      end
+    end
+  end
+
+  context 'when serializing an single object' do
+    it 'uses the correct serializer' do
+      data = VehicleSerializer.new(car, serializers: { Car: CarSerializer, Bus: BusSerializer }).to_hash[:data]
+
+      expect(data[:type]).to eq(:car)
+      expect(data[:attributes]).to eq(model: car.model, year: car.year, purchased_at: car.purchased_at)
+    end
+
+    context 'when there is no serializer given for the class' do
+      it 'raises ArgumentError' do
+        expect { VehicleSerializer.new(truck, serializers: { Car: CarSerializer, Bus: BusSerializer }).to_hash }
+          .to raise_error(ArgumentError, 'no serializer defined for Truck')
+      end
+    end
+
+    context 'when given an empty set of serializers' do
+      it 'uses the serializer being called' do
+        data = VehicleSerializer.new(truck, serializers: {}).to_hash[:data]
+        expect(data[:type]).to eq(:vehicle)
+        expect(data[:attributes]).to eq(model: truck.model, year: truck.year)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Port of https://github.com/Netflix/fast_jsonapi/pull/410. Fixes #121.

## What is the current behavior?

Collections of mixed type cannot be serialized with a different serializer for each class.

## What is the new behavior?

Serializers can be defined for classes by specifying the serializer for each class, for example:

```ruby
# single record
VehicleSerializer.new(car, serializers: { Car: CarSerializer, Bus: BusSerializer })

# collection
VehicleSerializer.new([car, bus], serializers: { Car: CarSerializer, Bus: BusSerializer })
```

If a object is attempted to be serialized when it doesn't have a corresponding serializer set, `ArgumentError` will be raised. If no serializers (or empty) is specified, the receiver class will be used.

From the original PR:

<blockquote>I foresee using this with ApplicationSerializer or the like as a base class (this makes more semantic sense to me). I experimented a bit with adding a generic abstract serializer to use, but I don't know if that's appropriate for this change. 

Another way to do this that I like would be to have a static method on ObjectSerializer, such as:

```ruby
FastJsonapi::ObjectSerializer.serialize(
  [car, bus],
  serializers: { Car: CarSerializer, Bus: BusSerializer }
)
```

but to do so we would need a base class to instantiate.</blockquote>
 (I believe this would still be a good idea, but there still isn't a base class to use.)

This has been in production at Pexels for a year and a half with no noticeable issues.

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)
