### PR TITLE
Fix namespace name per comment in #139

### DIFF
--- a/README.md
+++ b/README.md
@@ -747,7 +747,7 @@ See [docs](https://github.com/jsonapi-serializer/jsonapi-serializer#caching).
 
 ```diff
 - cache_options enabled: true, cache_length: 12.hours
-+ cache_options store: Rails.cache, namespace: 'fast-jsonapi', expires_in: 1.hour
++ cache_options store: Rails.cache, namespace: 'jsonapi-serializer', expires_in: 1.hour
 ```
 
 ## Contributing


### PR DESCRIPTION
(First time doing this, so please forgive me if I make a mistake)

## What is the current behavior?

Fix namespace to reflect new name
Per comment here - https://github.com/jsonapi-serializer/jsonapi-serializer/pull/139#discussion_r511688859

Change namespace from fastjson to jsonapi-serializer

## What is the new behavior?


```diff
- cache_options enabled: true, cache_length: 12.hours
+ cache_options store: Rails.cache, namespace: 'jsonapi-serializer', expires_in: 1.hour

## Checklist

Please make sure the following requirements are complete:

- [NA] Tests for the changes have been added (for bug fixes / features)
- [Y] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [NA] All automated checks pass (CI/CD)
