### PR TITLE
Allow to set relationship ids dynamicly

### DIFF
--- a/README.md
+++ b/README.md
@@ -658,7 +658,7 @@ set_type | Type name of Object | `set_type :movie`
 key | Key of Object | `belongs_to :owner, key: :user`
 set_id | ID of Object | `set_id :owner_id` or `set_id { \|record, params\| params[:admin] ? record.id : "#{record.name.downcase}-#{record.id}" }`
 cache_options | Hash with store to enable caching and optional further cache options | `cache_options store: ActiveSupport::Cache::MemoryStore.new, expires_in: 5.minutes`
-id_method_name | Set custom method name to get ID of an object (If block is provided for the relationship, `id_method_name` is invoked on the return value of the block instead of the resource object) | `has_many :locations, id_method_name: :place_ids`
+id_method_name | Set custom method name to get ID of an object (If block is provided for the relationship, `id_method_name` is invoked on the return value of the block instead of the resource object) | `has_many :locations, id_method_name: :place_ids` or `has_many :locations, id_method_name: ->(object) { (return ids value) }`
 object_method_name | Set custom method name to get related objects | `has_many :locations, object_method_name: :places`
 record_type | Set custom Object Type for a relationship | `belongs_to :owner, record_type: :user`
 serializer | Set custom Serializer for a relationship | `has_many :actors, serializer: :custom_actor`, `has_many :actors, serializer: MyApp::Api::V1::ActorSerializer`, or `has_many :actors, serializer -> (object, params) { (return a serializer class) }`

--- a/spec/fixtures/movie.rb
+++ b/spec/fixtures/movie.rb
@@ -80,7 +80,7 @@ class MovieSerializer
   )
   has_many(
     :actors_and_users,
-    id_method_name: :uid,
+    id_method_name: ->(actor_or_user) { actor_or_user.uid },
     polymorphic: {
       Actor => :actor,
       User => :user


### PR DESCRIPTION
## What is the current behavior?

Currently, we can set the relationship `id_method_name` only as a symbol or string. This does not work well when you want to use custom id value, because you have to create method with same value on object class, aka put serialization logic in to non-serializer class. Example:

```ruby
class User
  has_many :candies

  def api_candy_ids # I do not want to put this method here - it's used for serialization only!
    candies.map { |candy| "#{candy.id}-nom-nom" }
  end
end

class UserSerializer
  has_many :candies, id_method_name: :api_candy_ids
end
```

## What is the new behavior?

This PR allows to set `id_method_name` as a lambda/Proc so custom id logic can be defined directly in serializer:

```ruby
```ruby
class User
  has_many :candies
  # no need to write #api_candy_ids method here, yay!
end

class UserSerializer
  has_many :candies, id_method_name: -> (user) { user.candies.map { |candy| "#{candy.id}-nom-nom" } }
end
```

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [ ] All automated checks pass (CI/CD)
