### PR TITLE
Raise correct error on bad include even for serializer without any relationships

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -341,7 +341,7 @@ module FastJsonapi
         return if includes.blank?
 
         parse_includes_list(includes).keys.each do |include_item|
-          relationship_to_include = relationships_to_serialize[include_item]
+          relationship_to_include = relationships_to_serialize && relationships_to_serialize[include_item]
           raise(JSONAPI::Serializer::UnsupportedIncludeError.new(include_item, name)) unless relationship_to_include
 
           relationship_to_include.static_serializer # called for a side-effect to check for a known serializer class.

--- a/spec/integration/errors_spec.rb
+++ b/spec/integration/errors_spec.rb
@@ -15,8 +15,19 @@ RSpec.describe JSONAPI::Serializer do
       )
     end
 
-    it do
+    it 'raises correct error on bad include for serializer with other relationships' do
+      expect(ActorSerializer.relationships_to_serialize).to be_present
+
       expect { ActorSerializer.new(actor, include: ['bad_include']) }
+        .to raise_error(
+          JSONAPI::Serializer::UnsupportedIncludeError, /bad_include is not specified as a relationship/
+        )
+    end
+
+    it 'raises correct error on bad include for serializer with no relationships at all' do
+      expect(UserSerializer.relationships_to_serialize).to be_nil
+
+      expect { UserSerializer.new(actor, include: ['bad_include']) }
         .to raise_error(
           JSONAPI::Serializer::UnsupportedIncludeError, /bad_include is not specified as a relationship/
         )


### PR DESCRIPTION
## What is the current behavior?

If a serializer has no relationships but an include is passed, it raises a `NoMethodError` with an unhelpful error message.

## What is the new behavior?

If a serializer has no relationships but an include is passed, it raises a `JSONAPI::Serializer::UnsupportedIncludeError` with a helpful error message.

## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [ ] All automated checks pass (CI/CD)