### PR TITLE
Fix most likely copy/paste error

### DIFF
--- a/README.md
+++ b/README.md
@@ -460,7 +460,7 @@ class MovieSerializer
 
   belongs_to :primary_agent do |movie, params|
     # in here, params is a hash containing the `:current_user` key
-    params[:current_user].is_employee? ? true : false
+    params[:current_user]
   end
 end
 


### PR DESCRIPTION
this lambda yielding a bool for `belongs_to` might confuse readers or conflate the :if block

which would probably look something like this 

```ruby
belongs_to :primary_agent, if: proc { |movie, params| params[:current_user].present? } do |movie, params|
    # in here, params is a hash containing the `:current_user` key
    params[:current_user]
  end
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a
  relevant issue. -->

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added here. -->

## Checklist

Please make sure the following requirements are complete:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [ ] All automated checks pass (CI/CD)
