### PR TITLE
Fix Ruby3 compatibility issue with Procs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7]
+        ruby: [2.4, 2.5, 2.6, 2.7, 3.0]
 
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        ruby: [2.4, 2.5, 2.6, 2.7, 3.0]
+        ruby: [2.4, 2.5, 2.6, 2.7]
 
     steps:
     - uses: actions/checkout@master

--- a/lib/fast_jsonapi/helpers.rb
+++ b/lib/fast_jsonapi/helpers.rb
@@ -6,7 +6,15 @@ module FastJsonapi
     # @param [Array<Object>] *params any number of parameters to be passed to the Proc
     # @return [Object] the result of the Proc call with the supplied parameters
     def call_proc(proc, *params)
-      proc.call(*params.take(proc.parameters.length))
+      # The parameters array for a lambda created from a symbol (&:foo) differs
+      # from explictly defined procs/lambdas, so we can't deduce the number of
+      # parameters from the array length. Instead, look for an unnamed
+      # parameter in the first position just pass the record as the receiver obj.
+      if proc.parameters.length > 0 && proc.parameters.first[1].nil?
+        proc.call(params.first)
+      else
+        proc.call(*params.take(proc.parameters.length))
+      end
     end
   end
 end

--- a/lib/fast_jsonapi/helpers.rb
+++ b/lib/fast_jsonapi/helpers.rb
@@ -10,7 +10,7 @@ module FastJsonapi
       # from explictly defined procs/lambdas, so we can't deduce the number of
       # parameters from the array length. Instead, look for an unnamed
       # parameter in the first position just pass the record as the receiver obj.
-      if proc.parameters.length > 0 && proc.parameters.first[1].nil?
+      if proc.parameters.positive? && !proc.parameters.empty?
         proc.call(params.first)
       else
         proc.call(*params.take(proc.parameters.length))

--- a/lib/fast_jsonapi/helpers.rb
+++ b/lib/fast_jsonapi/helpers.rb
@@ -8,9 +8,10 @@ module FastJsonapi
     def call_proc(proc, *params)
       # The parameters array for a lambda created from a symbol (&:foo) differs
       # from explictly defined procs/lambdas, so we can't deduce the number of
-      # parameters from the array length. Instead, look for an unnamed
-      # parameter in the first position just pass the record as the receiver obj.
-      if proc.parameters.positive? && !proc.parameters.empty?
+      # parameters from the array length (and differs between Ruby 2.x and 3).
+      # In the case of negative arity -- unlimited/unknown argument count --
+      # just send the object to act as the method receiver.
+      if proc.arity.negative?
         proc.call(params.first)
       else
         proc.call(*params.take(proc.parameters.length))

--- a/lib/fast_jsonapi/relationship.rb
+++ b/lib/fast_jsonapi/relationship.rb
@@ -12,12 +12,7 @@ module FastJsonapi
       object_block:,
       serializer:,
       relationship_type:,
-      cached: false,
-      polymorphic:,
-      conditional_proc:,
-      transform_method:,
-      links:,
-      meta:,
+      polymorphic:, conditional_proc:, transform_method:, links:, meta:, cached: false,
       lazy_load_data: false
     )
       @owner = owner

--- a/lib/jsonapi/serializer/errors.rb
+++ b/lib/jsonapi/serializer/errors.rb
@@ -3,6 +3,7 @@
 module JSONAPI
   module Serializer
     class Error < StandardError; end
+
     class UnsupportedIncludeError < Error
       attr_reader :include_item, :klass
 

--- a/spec/fixtures/movie.rb
+++ b/spec/fixtures/movie.rb
@@ -50,7 +50,7 @@ class MovieSerializer
 
   attribute :released_in_year, &:year
   attributes :name
-  attribute :release_year do |object, params|
+  attribute :release_year do |object, _params|
     object.year
   end
 

--- a/spec/fixtures/movie.rb
+++ b/spec/fixtures/movie.rb
@@ -48,8 +48,9 @@ class MovieSerializer
 
   set_type :movie
 
+  attribute :released_in_year, &:year
   attributes :name
-  attribute :release_year do |object|
+  attribute :release_year do |object, params|
     object.year
   end
 


### PR DESCRIPTION
## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a
  relevant issue. -->
Fixes #158 (Shorthand Proc don't work with Ruby 3.0)

The Proc helper code uses the length of `Proc.parameters` to determine how many parameters the Proc/lambda accepts. However, lambdas created from a symbol (`&:foo`) take an unknown number of parameters, though they always take at least one, which is the 'receiver' object (i.e., an object that responds to the symbol).

In Ruby < 3.0 `Proc.parameters` for these lambdas always had a length of one with an unnamed parameter of type `rest`:
```
>> :foo.to_proc.parameters
=> [[:rest]]
```
This sort of worked since the proc helper just stuffed the record into the first parameter as the receiver. In Ruby 3.0, though, `Proc.parameters` now contains two unnamed elements:
```
>> :foo.to_proc.parameters
=> [[:req], [:rest]]
```
I assume that the change is to reflect that these lambdas do require at least the receiver. There's no elegant way to catch this case, so I tweaked the proc helper to detect when there is an unnamed parameter in the first position and treat it as only requiring the record. I also added an example of this case in the fixtures.
## Checklist

Please make sure the following requirements are complete:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [x] All automated checks pass (CI/CD)
