### PR TITLE
Allow for a single associated record that is enumerable.

### DIFF
--- a/lib/fast_jsonapi/relationship.rb
+++ b/lib/fast_jsonapi/relationship.rb
@@ -107,7 +107,7 @@ module FastJsonapi
 
       return unless associated_object = fetch_associated_object(record, params)
 
-      if associated_object.respond_to? :map
+      if associated_object.respond_to? :to_ary
         return associated_object.map do |object|
           id_hash_from_record object, params
         end

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -172,7 +172,7 @@ module FastJsonapi
 
           next unless relationship_item&.include_relationship?(record, params)
 
-          included_objects = Array(relationship_item.fetch_associated_object(record, params))
+          included_objects = Array.wrap(relationship_item.fetch_associated_object(record, params))
           next if included_objects.empty?
 
           static_serializer = relationship_item.static_serializer

--- a/spec/fixtures/debut.rb
+++ b/spec/fixtures/debut.rb
@@ -1,0 +1,7 @@
+Debut = Struct.new(:id, :location)
+
+class DebutSerializer
+  include JSONAPI::Serializer
+
+  attributes :location
+end

--- a/spec/fixtures/movie.rb
+++ b/spec/fixtures/movie.rb
@@ -8,7 +8,8 @@ class Movie
     :actor_ids,
     :polymorphics,
     :owner,
-    :owner_id
+    :owner_id,
+    :debut
   )
 
   def self.fake(id = nil)
@@ -104,6 +105,8 @@ class MovieSerializer
   ) do |obj|
     obj.polymorphics
   end
+
+  has_one(:debut) { |obj| obj.debut }
 end
 
 module Cached

--- a/spec/integration/relationships_spec.rb
+++ b/spec/integration/relationships_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe JSONAPI::Serializer do
     poly_act.movies = [Movie.fake]
     mov.polymorphics = [User.fake, poly_act]
     mov.actor_or_user = Actor.fake
+    mov.debut = Debut.new(SecureRandom.uuid, 'Los Angeles')
     mov
   end
   let(:params) { {} }
@@ -139,6 +140,16 @@ RSpec.describe JSONAPI::Serializer do
           expect(serialized['included']).to include(
             have_type('actor').and(have_id(movie.actor_or_user.uid))
           )
+        end
+      end
+
+      context 'with enumerable data types' do
+        let(:params) do
+          { include: [:debut] }
+        end
+
+        it do
+          expect(serialized['included']).to include(have_type('debut').and(have_id(movie.debut.id)))
         end
       end
     end


### PR DESCRIPTION
Example: A Struct.  Ideally we could still serialize an associated single record if it is a Struct.

## What is the current behavior?

#187 

## What is the new behavior?

<!-- Please describe the behavior or changes that are being added here. -->

## Checklist

Please make sure the following requirements are complete:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [ ] All automated checks pass (CI/CD)
