### PR TITLE
Use #cache_key_with_version instead of #cache_key

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 - ...
 
+## [2.3.0] - 2021-06-05
+- optimize the cache performance by batch load the cache
+- support proc on cache_options namespace
+- cache_options namespace merged into cache key
+- temp disable fieldset support, expect to bring back that in next version
+
 ## [2.2.0] - 2021-03-11
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -752,6 +752,30 @@ See [docs](https://github.com/jsonapi-serializer/jsonapi-serializer#caching).
 + cache_options store: Rails.cache, namespace: 'jsonapi-serializer', expires_in: 1.hour
 ```
 
+# Chowbus Domain Modification
+
+## Caching
+
+Utilize the batch loader to implement mult_w/r of caching, it resolve the N+1 on caching redis trips.
+It will boost performance more better than previous multiple round trips to cache store.
+
+:exclamation::exclamation::exclamation: Ceavet
+* the original sprease fieldset support is removed to boots performance and simple implementation
+* the meta attribute on relationships is cached, so please do not put time sensitive content in that, if you really need to, you can put it data meta field
+* all the record need to support `#cache_key` method to properly generate cache key
+* fieldset support is temp disable, looking forward to add it back really soon
+
+### Namespace base on params
+cache namespace could be dynamically generated base on serializer params
+```ruby
+cache_options(
+  store: Rails.cache,
+  namespace: ->(object, params) {
+    "#{object.cache_key}:#{params[:meal].map(&:cache_key).to_s}"
+  }
+)
+```
+
 ## Contributing
 
 Please follow the instructions we provide as part of the issue and

--- a/jsonapi-serializer.gemspec
+++ b/jsonapi-serializer.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |gem|
   gem.extra_rdoc_files = ['LICENSE.txt', 'README.md']
 
   gem.add_runtime_dependency('activesupport', '>= 4.2')
+  gem.add_runtime_dependency('batch-loader', '~> 2.0.0')
 
   gem.add_development_dependency('activerecord')
   gem.add_development_dependency('bundler')

--- a/lib/fast_jsonapi/relationship.rb
+++ b/lib/fast_jsonapi/relationship.rb
@@ -155,6 +155,8 @@ module FastJsonapi
                                  end
     end
 
+    # this relationship meta attribute is intend to be cached
+    # since the use case is unclear about time sensitive
     def add_meta_hash(record, params, output_hash)
       output_hash[key][:meta] = if meta.is_a?(Proc)
                                   FastJsonapi.call_proc(meta, record, params)

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -66,10 +66,15 @@ module FastJsonapi
         FastJsonapi.call_proc(meta_to_serialize, record, params)
       end
 
-      # move the namespace to be part of cache_key
+      # Move the namespace to be part of cache_key
       # since ActiveSupport doesn't support multi read with different namespaces
+      #
+      # Use #cache_key_with_version instead of #cache_key because we don't
+      # pass AR objects as keys to cache store and thus we can't leverage the
+      # built-in cache versioning from rails 6. This is a good opportunity for
+      # future improvement.
       def generate_cache_key(record, namespace)
-        "#{namespace}-#{record.cache_key}"
+        "#{namespace}-#{record.cache_key_with_version}"
       end
 
       def record_hash(record, fieldset, includes_list, params = {})

--- a/lib/jsonapi/serializer/version.rb
+++ b/lib/jsonapi/serializer/version.rb
@@ -1,5 +1,5 @@
 module JSONAPI
   module Serializer
-    VERSION = '2.2.0'.freeze
+    VERSION = '2.3.0'.freeze
   end
 end

--- a/spec/fixtures/_user.rb
+++ b/spec/fixtures/_user.rb
@@ -11,6 +11,10 @@ class User
     faked.email = FFaker::Internet.email
     faked
   end
+
+  def cache_key
+    "#{uid}_cache_key"
+  end
 end
 
 class NoSerializerUser < User

--- a/spec/fixtures/actor.rb
+++ b/spec/fixtures/actor.rb
@@ -11,6 +11,10 @@ class Actor < User
     faked
   end
 
+  def cache_key
+    "#{uid}_cache_key"
+  end
+
   def movie_urls
     {
       movie_url: movies[0]&.url
@@ -68,6 +72,26 @@ module Cached
     cache_options(
       store: ActiveSupport::Cache::MemoryStore.new,
       namespace: 'test'
+    )
+
+    attribute :nest_batch do |object|
+      BatchLoader.for(object).batch(replace_methods: false) do |objects, loader|
+        objects.each do |obj|
+          loader.call(obj, obj.uid)
+        end
+      end
+    end
+  end
+
+  class WithParamNamespaceActorSerializer < ::ActorSerializer
+    # TODO: Fix this, the serializer gets cached on inherited classes...
+    has_many :played_movies, serializer: :movie do |object|
+      object.movies
+    end
+
+    cache_options(
+      store: ActiveSupport::Cache::MemoryStore.new,
+      namespace: ->(record, params) { "#{params[:actor_gender]}" }
     )
   end
 end

--- a/spec/fixtures/movie.rb
+++ b/spec/fixtures/movie.rb
@@ -22,6 +22,10 @@ class Movie
     faked
   end
 
+  def cache_key
+    "#{id}_cache_key"
+  end
+
   def url(obj = nil)
     @url ||= FFaker::Internet.http_url
     return @url if obj.nil?

--- a/spec/integration/caching_spec.rb
+++ b/spec/integration/caching_spec.rb
@@ -9,21 +9,40 @@ RSpec.describe JSONAPI::Serializer do
     faked.movies = [movie]
     faked
   end
-  let(:cache_store) { Cached::ActorSerializer.cache_store_instance }
 
   describe 'with caching' do
+    let(:cache_store) { Cached::ActorSerializer.cache_store_instance }
     it do
-      expect(cache_store.delete(actor, namespace: 'test')).to be(false)
+      cache_store.clear
+      expect(cache_store.delete("j16r-test-#{actor.cache_key}")).to be(false)
+      expect(cache_store).to receive(:read_multi).once.and_call_original
+      expect(cache_store).to receive(:write_multi).once.and_call_original
 
-      Cached::ActorSerializer.new(
+      JSON.dump(Cached::ActorSerializer.new(
         [actor, actor], include: ['played_movies', 'played_movies.owner']
-      ).serializable_hash
+      ).serializable_hash)
 
-      expect(cache_store.delete(actor, namespace: 'test')).to be(true)
-      expect(cache_store.delete(actor.movies[0], namespace: 'test')).to be(true)
-      expect(
-        cache_store.delete(actor.movies[0].owner, namespace: 'test')
-      ).to be(false)
+      expect(cache_store.delete("j16r-test-#{actor.cache_key}")).to be(true)
+      expect(cache_store.delete("j16r-test-#{actor.movies[0].cache_key}")).to be(true)
+      expect(cache_store.delete("j16r-test-#{actor.movies[0].owner.cache_key}")).to be(false)
+    end
+
+    context 'with params determined namespace' do
+      let(:cache_store) { Cached::WithParamNamespaceActorSerializer.cache_store_instance }
+      it do
+        cache_store.clear
+        expect(cache_store.delete("j16r-male-#{actor.cache_key}")).to be(false)
+
+        JSON.dump(Cached::WithParamNamespaceActorSerializer.new(
+          [actor, actor],
+          include: ['played_movies', 'played_movies.owner'],
+          params: { actor_gender: :male }
+        ).serializable_hash)
+
+        expect(cache_store.delete("j16r-male-#{actor.cache_key}")).to be(true)
+        expect(cache_store.delete("j16r-test-#{actor.movies[0].cache_key}")).to be(true)
+        expect(cache_store.delete("j16r-test-#{actor.movies[0].owner.cache_key}")).to be(false)
+      end
     end
 
     context 'without relationships' do
@@ -37,9 +56,10 @@ RSpec.describe JSONAPI::Serializer do
     end
   end
 
+  # disable those tests since fieldset support is dropped
   describe 'with caching and different fieldsets' do
     context 'when fieldset is provided' do
-      it 'includes the fieldset in the namespace' do
+      xit 'includes the fieldset in the namespace' do
         expect(cache_store.delete(actor, namespace: 'test')).to be(false)
 
         Cached::ActorSerializer.new(
@@ -64,7 +84,7 @@ RSpec.describe JSONAPI::Serializer do
       let(:actor_keys) { %i[first_name last_name more_fields yet_more_fields so_very_many_fields] }
       let(:digest_key) { Digest::SHA1.hexdigest(actor_keys.join('_')) }
 
-      it 'includes the hashed fieldset in the namespace' do
+      xit 'includes the hashed fieldset in the namespace' do
         Cached::ActorSerializer.new(
           [actor], fields: { actor: actor_keys }
         ).serializable_hash


### PR DESCRIPTION
With Rails 6 cache-versioning enabled, `#cache_key` will no longer return timestamp and that breaks this implementation as we don't send AR objects to cache stores as keys. This PR changes to use cache_key_with_version instead so we'll always get timestamp in the key.