### PR TITLE
Add Ruby 3.1 to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,10 +4,10 @@ on: [push, pull_request]
 
 jobs:
   tests:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.4, 2.7, 3.0, truffleruby-head]
+        ruby: [2.4, 2.7, '3.0', 3.1, truffleruby-head]
 
     steps:
     - uses: actions/checkout@master

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,6 +42,9 @@ Performance/TimesMap:
   Exclude:
     - 'spec/**/**.rb'
 
+Gemspec/RequiredRubyVersion:
+  Enabled: false
+
 # TODO: Fix these...
 Style/Documentation:
   Enabled: false

--- a/jsonapi-serializer.gemspec
+++ b/jsonapi-serializer.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |gem|
 
   gem.summary = 'Fast JSON:API serialization library'
   gem.description = 'Fast, simple and easy to use '\
-    'JSON:API serialization library (also known as fast_jsonapi).'
+                    'JSON:API serialization library (also known as fast_jsonapi).'
   gem.homepage = 'https://github.com/jsonapi-serializer/jsonapi-serializer'
   gem.licenses = ['Apache-2.0']
   gem.files = Dir['lib/**/*']
@@ -33,4 +33,5 @@ Gem::Specification.new do |gem|
   gem.add_development_dependency('rubocop-rspec')
   gem.add_development_dependency('simplecov')
   gem.add_development_dependency('sqlite3')
+  gem.metadata['rubygems_mfa_required'] = 'true'
 end

--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'active_support'
 require 'active_support/time'
 require 'active_support/concern'
 require 'active_support/inflector'
@@ -133,9 +134,7 @@ module FastJsonapi
       def reflected_record_type
         return @reflected_record_type if defined?(@reflected_record_type)
 
-        @reflected_record_type ||= begin
-          name.split('::').last.chomp('Serializer').underscore.to_sym if name&.end_with?('Serializer')
-        end
+        @reflected_record_type ||= (name.split('::').last.chomp('Serializer').underscore.to_sym if name&.end_with?('Serializer'))
       end
 
       def set_key_transform(transform_name)

--- a/lib/fast_jsonapi/serialization_core.rb
+++ b/lib/fast_jsonapi/serialization_core.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'active_support'
 require 'active_support/concern'
 require 'digest/sha1'
 

--- a/lib/jsonapi/serializer/instrumentation.rb
+++ b/lib/jsonapi/serializer/instrumentation.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'active_support/notifications'
 
 module JSONAPI

--- a/spec/fixtures/_user.rb
+++ b/spec/fixtures/_user.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'active_support/cache'
 
 class User

--- a/spec/fixtures/actor.rb
+++ b/spec/fixtures/actor.rb
@@ -1,3 +1,4 @@
+require 'active_support'
 require 'active_support/cache'
 require 'jsonapi/serializer/instrumentation'
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -6,6 +6,7 @@ SimpleCov.start do
 end
 SimpleCov.minimum_coverage 90
 
+require 'active_support'
 require 'active_support/core_ext/object/json'
 require 'jsonapi/serializer'
 require 'ffaker'


### PR DESCRIPTION
In addition to adding 3.1 to the list of Rubies in CI this PR:

1. Fixes the unquoted 3.0, which is currently truncated to '3'.  With that truncation, it loads the latest Ruby 3, which is 3.1.0.  Not the intention.
2. Fixes some layout and style lints
3. Adds the MFA required to gem publication, to satisfy Rubocop
4. Disables the gemspec required version cop.  If there's a desire to specify a minimum Ruby version the gemspec can be updated appropriately.
5. Explicitly requires 'active_support' before requiring any components.  This ensures that referenced ActiveSupport modules are properly loaded.  Discussion can be found [here](https://github.com/rails/rails/issues/43851)

## What is the current behavior?

CI is not green.  CI doesn't run against a 3.0.x Ruby.  Rubocop fails.

## What is the new behavior?

CI runs green.  CI runs against 2.4, 2.7, 3.0, 3.1, and truffleruby-head Rubies.  Rubocop passes.

## Checklist

Please make sure the following requirements are complete:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [X] All automated checks pass (CI/CD)
