### PR TITLE
Remove key transform from record type

### DIFF
--- a/lib/fast_jsonapi/object_serializer.rb
+++ b/lib/fast_jsonapi/object_serializer.rb
@@ -163,7 +163,7 @@ module FastJsonapi
       end
 
       def set_type(type_name)
-        self.record_type = run_key_transform(type_name)
+        self.record_type = type_name
       end
 
       def set_id(id_name = nil, &block)

--- a/spec/integration/key_transform_spec.rb
+++ b/spec/integration/key_transform_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe JSONAPI::Serializer do
   describe 'camel case key tranformation' do
     it do
       expect(serialized['data']).to have_id(actor.uid)
-      expect(serialized['data']).to have_type('UserActor')
+      expect(serialized['data']).to have_type('user_actor')
       expect(serialized['data']).to have_attribute('FirstName')
       expect(serialized['data']).to have_relationship('PlayedMovies')
       expect(serialized['data']).to have_link('MovieUrl').with_value(nil)


### PR DESCRIPTION
Currently if a key transform is specified, it will also apply it to the value of the record_type. There are two problems with this:
* it's misleading - the record_type value is not a key
* it breaks the integration with our Angular frontend, which relies on the record type to construct the url to the resource

To fix this, the transformation of the record_type value has been removed.
