### PR TITLE
Clarify README wording related to contributions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
 # JSON:API Serialization Library
 
-## :warning: :construction: [At the moment, contributions are welcome only for v3](https://github.com/jsonapi-serializer/jsonapi-serializer/pull/141)! :construction: :warning:
+## :warning: :construction: v2 (the `master` branch) is in maintenance mode! :construction: :warning:
+
+We'll gladly accept bugfixes and security-related fixes for v2 (the `master` branch), but at this stage, contributions for new features/improvements are welcome only for v3. Please feel free to leave comments in the [v3 Pull Request](https://github.com/jsonapi-serializer/jsonapi-serializer/pull/141). 
+
+---
 
 A fast [JSON:API](https://jsonapi.org/) serializer for Ruby Objects.
 


### PR DESCRIPTION
## What is the current behavior?

The current wording in the README has caused quite a lot of stir (see https://github.com/jsonapi-serializer/jsonapi-serializer/pull/141). It has also confused me in the past.

## What is the new behavior?

The README now better states the maintainer's intent as outlined in his response:

![Screenshot 2022-04-04 at 10 03 16](https://user-images.githubusercontent.com/3749/161500538-7a7dacb6-3b82-46bc-aaf1-34b79309b775.png)

(source: https://github.com/jsonapi-serializer/jsonapi-serializer/pull/141#issuecomment-1028201018)