### PR TITLE
Remove the Error constant

### DIFF
--- a/lib/jsonapi/serializer/errors.rb
+++ b/lib/jsonapi/serializer/errors.rb
@@ -2,9 +2,7 @@
 
 module JSONAPI
   module Serializer
-    class Error < StandardError; end
-
-    class UnsupportedIncludeError < Error
+    class UnsupportedIncludeError < StandardError
       attr_reader :include_item, :klass
 
       def initialize(include_item, klass)


### PR DESCRIPTION
It conflicts with the [jsonapi_serializers](https://github.com/fotinakis/jsonapi-serializers/) gem. It's easy to remove it here because it is used only in a single place.

It isn't the nicest way of solving the problem, but all the other ways, apart from not using one of the gems or removing the namespace completely of the gem, aren't nice too.

This only solves my problem; however, at least it does so without causing any harm.
