### PR TITLE
Add Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
## What is the current behavior?

GitHub Actions in CI configuration are not updated as new versions are made available.

## What is the new behavior?

This PR adds Dependabot for GitHub Actions as described here - https://docs.github.com/en/code-security/dependabot/working-with-dependabot/keeping-your-actions-up-to-date-with-dependabot

As the checkout action is currently out of date, Dependabot will open a PR to update it if and when this PR is merged.

## Checklist

Please make sure the following requirements are complete:

- Tests for the changes have been added (for bug fixes / features) - N/A for CI configuration change
- Docs have been reviewed and added / updated if needed (for bug fixes /
  features) -  - N/A for CI configuration change
- [ ] All automated checks pass (CI/CD)
