### PR TITLE
Add how to order `has_many` relationship

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ article in the `docs` folder for any questions related to methodology.
   * [Conditional Attributes](#conditional-attributes)
   * [Conditional Relationships](#conditional-relationships)
   * [Specifying a Relationship Serializer](#specifying-a-relationship-serializer)
+  * [Ordering `has_many` Relationship](#ordering-has_many-relationship)
   * [Sparse Fieldsets](#sparse-fieldsets)
   * [Using helper methods](#using-helper-methods)
 * [Performance Instrumentation](#performance-instrumentation)
@@ -575,6 +576,20 @@ class MovieSerializer
     else
       ActorSerializer
     end
+  end
+end
+```
+
+### Ordering `has_many` Relationship
+
+You can order the `has_many` relationship by providing a block:
+
+```ruby
+class MovieSerializer
+  include JSONAPI::Serializer
+
+  has_many :actors do |movie|
+    movie.actors.order(position: :asc)
   end
 end
 ```


### PR DESCRIPTION
## What is the current behavior?

There's no guide on how to order `has_many` relationship.

## What is the new behavior?

There will be a guide on how to order the `has_many` relationship in the `README.md` file.

## Checklist

Please make sure the following requirements are complete:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [ ] All automated checks pass (CI/CD)
