### PR TITLE
Add Ruby 3.2 to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: [2.4, 2.7, '3.0', 3.1, truffleruby-head]
+        ruby: [2.4, 2.7, '3.0', 3.1, 3.2, truffleruby-head]
 
     steps:
     - uses: actions/checkout@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,19 @@ jobs:
     - name: Sets up the environment
       run: |
         sudo apt-get install libsqlite3-dev
+
+    - name: Install legacy bundler for Ruby 2.4
+      if: ${{ matrix.ruby == 2.4 }}
+      run: |
+        gem install -q bundler -v 2.3.26 
+
+    - name: Install bundler 2.4+ for modern Rubies
+      if: ${{ matrix.ruby != 2.4 }}
+      run: |
         gem install -q bundler
+
+    - name: Run bundle install
+      run: |
         bundle install
 
     - name: Runs code QA and tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,11 +6,12 @@ jobs:
   tests:
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         ruby: [2.4, 2.7, '3.0', 3.1, 3.2, truffleruby-head]
 
     steps:
-    - uses: actions/checkout@master
+    - uses: actions/checkout@v3
 
     - name: Sets up the Ruby version
       uses: ruby/setup-ruby@v1

--- a/jsonapi-serializer.gemspec
+++ b/jsonapi-serializer.gemspec
@@ -11,7 +11,7 @@ Gem::Specification.new do |gem|
   gem.email = ''
 
   gem.summary = 'Fast JSON:API serialization library'
-  gem.description = 'Fast, simple and easy to use '\
+  gem.description = 'Fast, simple and easy to use ' \
                     'JSON:API serialization library (also known as fast_jsonapi).'
   gem.homepage = 'https://github.com/jsonapi-serializer/jsonapi-serializer'
   gem.licenses = ['Apache-2.0']

--- a/lib/extensions/has_one.rb
+++ b/lib/extensions/has_one.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-::ActiveRecord::Associations::Builder::HasOne.class_eval do
+ActiveRecord::Associations::Builder::HasOne.class_eval do
   # Based on
   # https://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations/builder/collection_association.rb#L50
   # https://github.com/rails/rails/blob/master/activerecord/lib/active_record/associations/builder/singular_association.rb#L11

--- a/spec/integration/instrumentation_spec.rb
+++ b/spec/integration/instrumentation_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe JSONAPI::Serializer do
   it do
     payload = event_name = nil
     notification_name =
-      "#{::JSONAPI::Serializer::Instrumentation::NOTIFICATION_NAMESPACE}serializable_hash"
+      "#{JSONAPI::Serializer::Instrumentation::NOTIFICATION_NAMESPACE}serializable_hash"
 
     ActiveSupport::Notifications.subscribe(
       notification_name

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,10 +1,11 @@
-require 'simplecov'
-
-SimpleCov.start do
-  add_group 'Lib', 'lib'
-  add_group 'Tests', 'spec'
+unless RUBY_ENGINE == 'truffleruby'
+  require 'simplecov'
+  SimpleCov.start do
+    add_group 'Lib', 'lib'
+    add_group 'Tests', 'spec'
+  end
+  SimpleCov.minimum_coverage 90
 end
-SimpleCov.minimum_coverage 90
 
 require 'active_support'
 require 'active_support/core_ext/object/json'


### PR DESCRIPTION
## What is the current behavior?

Ruby 3.2 is not in the CI matrix
The version of bundler installed is incompatible with Ruby on legacy Ruby jobs (2.4)
Rubocop fails
Truffleruby build fails because of simplecov errors

## What is the new behavior?

Ruby 3.2 is added to the Ci matrix
A compatible version of bundler is installed for Ruby 2.4
Rubocop finds no lints, allowing CI to pass
Simplecov is disabled for Truffleruby, allowing that job to pass
CI runs green.

Note this is intended as a PR for the current version of `jsonapi-serializer`, not the rewrite.

## Checklist

Please make sure the following requirements are complete:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been reviewed and added / updated if needed (for bug fixes /
  features)
- [X] All automated checks pass (CI/CD)
